### PR TITLE
Fake camera usage

### DIFF
--- a/gui/tabs/tasks_tab.cpp
+++ b/gui/tabs/tasks_tab.cpp
@@ -49,7 +49,7 @@ namespace TasksTab {
 					State.rpcQueue.push(new RpcPlayAnimation(6));
 				}
 
-				if(ImGui::Button("Play Trash Animation"))
+				if (ImGui::Button("Play Trash Animation"))
 				{
 					State.rpcQueue.push(new RpcPlayAnimation(10));
 				}
@@ -64,6 +64,11 @@ namespace TasksTab {
 					{
 						State.rpcQueue.push(new RpcSetScanner(false));
 					}
+				}
+
+				if (ImGui::Checkbox("Fake Cameras In Use", &State.FakeCameraUsage))
+				{
+					State.rpcQueue.push(new RpcRepairSystem(SystemTypes__Enum_Security, (State.FakeCameraUsage ? 1 : 0)));
 				}
 
 				ImGui::EndTabItem();

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -100,6 +100,8 @@ public:
     Camera* FollowerCam = nullptr;
     bool EnableZoom = false;
 
+    bool FakeCameraUsage = false;
+
     ImVec4 SelectedColor = ImVec4(0.502f, 0.075f, 0.256f, 0.5f);
 
 	int SelectedColorId = 0;


### PR DESCRIPTION
This will cause the cameras to light up red as if someone is in security watching them, despite no one being there.