### PR TITLE
auto release on semver-named tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       
       - name: Upload Release Artifact
         if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: Release
           path: Release_${{ github.sha }}.zip
@@ -52,7 +52,7 @@ jobs:
         
       - name: Upload Debug Artifact
         if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
+        uses: actions/upload-artifact@v2.2.3
         with:
           name: Debug
           path: Debug_${{ github.sha }}.zip
@@ -79,14 +79,14 @@ jobs:
             echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
             echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
             echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
-            
+	    
       - name: Download Release Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.9
         with:
           name: Release
 	  
       - name: Download Debug Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.9
         with:
           name: Debug
 	  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,12 +84,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: Release
-		  
+	  
       - name: Download Debug Artifact
         uses: actions/download-artifact@v2
         with:
           name: Debug
-			
+	  
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
         uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
   Build_Debug:
     runs-on: windows-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      
       - name: Build Debug
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Package Release Builds
         if: ${{ github.event_name == 'push' }}
         run: tar -caf Release_${{ github.sha }}.zip Release/AmongUsMenu.dll Release_Version/version.dll LICENSE
-      
+        
       - name: Upload Release Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.3
         with:
           name: Release
           path: Release_${{ github.sha }}.zip
-            
+          
   Build_Debug:
     runs-on: windows-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
         with:
           name: Debug
           path: Debug_${{ github.sha }}.zip
-            
+          
   AutoRelease:
     if: ${{ github.event_name == 'push' }}
     runs-on: windows-latest
@@ -68,8 +68,8 @@ jobs:
         with:
           input_string: ${{ github.ref }}
           version_extractor_regex: '\/v(.*)$'
-        
-        # please keep this for an adjustment period, will help diagnose any issues
+          
+      # please keep this for an adjustment period, will help diagnose any issues
       - name: Debug semver
         run: |
             echo 'major: ${{ steps.semver_parser.outputs.major }}'
@@ -84,12 +84,12 @@ jobs:
         uses: actions/download-artifact@v2.0.9
         with:
           name: Release
-	  
+      
       - name: Download Debug Artifact
         uses: actions/download-artifact@v2.0.9
         with:
           name: Debug
-	  
+      
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
         uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
@@ -111,8 +111,10 @@ jobs:
         id: get_tag
         shell: bash
         run: echo ::set-output name=THIS_TAG::${GITHUB_REF/refs\/tags\//}
+        
       - name: Debug tag parsing
         run: echo '${{ steps.get_tag.outputs.THIS_TAG }}'
+        
       - name: Discord Notification
         uses: rjstone/discord-webhook-notify@v1.0.4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
             Debug_${{ github.sha }}.zip
   
   Notification:
-    if: ${{ github.event_name == 'push' && github.repository == "BitCrackers/AmongUsMenu" }}
+    if: ${{ github.event_name == 'push' && github.repository == 'BitCrackers/AmongUsMenu' }}
     runs-on: ubuntu-latest
     needs: [Release, Debug]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,57 @@ on:
       - main
   
 jobs:
-  BuildAndRelease:
+  Build_Release:
     runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      
+      - name: Build Release
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release'
+        
+      - name: Build Release_Version
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
+        
+      - name: Package Release Builds
+        if: ${{ github.event_name == 'push' }}
+        run: tar -caf Release_${{ github.sha }}.zip Release/AmongUsMenu.dll Release_Version/version.dll LICENSE
+      
+      - name: Upload Release Artifact
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: Release
+          path: Release_${{ github.sha }}.zip
+            
+  Build_Debug:
+    runs-on: windows-latest
+    steps:
+      - name: Build Debug
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug'
+        
+      - name: Build Debug_Version
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
+        
+      - name: Package Debug Builds
+        if: ${{ github.event_name == 'push' }}
+        run: tar -caf Debug_${{ github.sha }}.zip Debug/AmongUsMenu.dll Debug_Version/version.dll LICENSE
+        
+      - name: Upload Debug Artifact
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/upload-artifact@v2.2.1
+        with:
+          name: Debug
+          path: Debug_${{ github.sha }}.zip
+            
+  AutoRelease:
+    if: ${{ github.event_name == 'push' }}
+    runs-on: windows-latest
+    needs: [Build_Release, Build_Debug]
     steps:
       - name: Parse tag semver
         uses: booxmedialtd/ws-action-parse-semver@3576f3a20a39f8752fe0d8195f5ed384090285dc
@@ -30,60 +79,17 @@ jobs:
             echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
             echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
             echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
-          
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      
-        # begin release builds
-      - name: Build Release
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release'
-        
-      - name: Build Release_Version
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
-      
-      # used solely for backwards compat, can remove once bitbot is updated to use the release instead of the artifacts
-      - name: Upload Release Artifact
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
+            
+      - name: Download Release Artifact
+        uses: actions/download-artifact@v2
         with:
           name: Release
-          path: |
-            ./Release/AmongUsMenu.dll
-            ./Release_Version/version.dll
-            ./LICENSE
-            
-      - name: Package Release Build
-        if: ${{ github.event_name == 'push' }}
-        run: tar -caf Release_${{ github.sha }}.zip Release/AmongUsMenu.dll Release_Version/version.dll LICENSE
-        # end release builds
-        
-        # begin debug builds
-      - name: Build Debug
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug'
-        
-      - name: Build Debug_Version
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
-        
-        # used solely for backwards compat, can remove once bitbot is updated to use the release instead of the artifacts
-      - name: Upload Artifact
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
+		  
+      - name: Download Debug Artifact
+        uses: actions/download-artifact@v2
         with:
           name: Debug
-          path: |
-            ./Debug/AmongUsMenu.dll
-            ./Debug_Version/version.dll
-            ./LICENSE
-            
-      - name: Package Builds
-        if: ${{ github.event_name == 'push' }}
-        run: tar -caf Debug_${{ github.sha }}.zip Debug/AmongUsMenu.dll Debug_Version/version.dll LICENSE
-        #end debug builds
-      
+			
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
         uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
@@ -94,12 +100,11 @@ jobs:
           files: |
             Release_${{ github.sha }}.zip
             Debug_${{ github.sha }}.zip
-            
   
   Notification:
     if: ${{ github.event_name == 'push' && github.repository == 'BitCrackers/AmongUsMenu' }}
     runs-on: ubuntu-latest
-    needs: [BuildAndRelease]
+    needs: [AutoRelease]
     steps:
       - name: Parse tag into env
         # credit: mcraiha via [https://github.community/t/how-to-get-just-the-tag-name/16241/17]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - main
   
 jobs:
-  Release:
+  BuildAndRelease:
     runs-on: windows-latest
     steps:
       - name: Parse tag semver
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       
+        # begin release builds
       - name: Build Release
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release'
@@ -43,7 +44,7 @@ jobs:
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
       
       # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
-      - name: Upload Artifact
+      - name: Upload Release Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
         with:
@@ -53,48 +54,12 @@ jobs:
             ./Release_Version/version.dll
             ./LICENSE
             
-      - name: Package Builds
+      - name: Package Release Build
         if: ${{ github.event_name == 'push' }}
         run: tar -caf Release_${{ github.sha }}.zip Release/AmongUsMenu.dll Release_Version/version.dll LICENSE
-      
-      - name: Automatic Releases
-        if: ${{ github.event_name == 'push' }}
-        uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
-        id: "automatic_releases"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: ${{ steps.semver_parser.outputs.prerelease != 0 }}
-          title: "Release Build"
-          files: |
-            Release_${{ github.sha }}.zip
-      # note, we can invoke the discord webhook here and send it ${{ steps.automatic_releases.outputs.upload_url }} for a direct link to the release
-      # if we do that we can probably remove the artifact uploads entirely unless there's a reason to keep them?
-      
-  Debug:
-    # note, this job can probably be merged into the above job for a slightly faster action
-    runs-on: windows-latest
-    steps:
-      - name: Parse tag semver
-        uses: booxmedialtd/ws-action-parse-semver@3576f3a20a39f8752fe0d8195f5ed384090285dc
-        id: semver_parser
-        with:
-          input_string: ${{ github.ref }}
-          version_extractor_regex: '\/v(.*)$'
+        # end release builds
         
-        # please keep this for an adjustment period, will help diagnose any issues
-      - name: Debug semver
-        run: |
-            echo 'major: ${{ steps.semver_parser.outputs.major }}'
-            echo 'minor: ${{ steps.semver_parser.outputs.minor }}'
-            echo 'patch: ${{ steps.semver_parser.outputs.patch }}'
-            echo 'feature (is pre-release?): ${{ steps.semver_parser.outputs.prerelease }}'
-            echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
-            echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
-            echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
-            
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      
+        # begin debug builds
       - name: Build Debug
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug'
@@ -102,8 +67,8 @@ jobs:
       - name: Build Debug_Version
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
-      
-      # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
+        
+        # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
@@ -117,7 +82,8 @@ jobs:
       - name: Package Builds
         if: ${{ github.event_name == 'push' }}
         run: tar -caf Debug_${{ github.sha }}.zip Debug/AmongUsMenu.dll Debug_Version/version.dll LICENSE
-        
+        #end debug builds
+      
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
         uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
@@ -125,14 +91,20 @@ jobs:
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: ${{ steps.semver_parser.outputs.prerelease != 0 }}
-          title: "Debug Build"
           files: |
+            Release_${{ github.sha }}.zip
             Debug_${{ github.sha }}.zip
+            
+        # note, we can invoke the discord webhook here and send it ${{ steps.automatic_releases.outputs.upload_url }} for a direct link to the release
+        # if we do that we can probably remove the artifact uploads entirely unless there's a reason to keep them?
+      - name: Debug Discord
+        if: ${{ github.event_name == 'push' }}
+        run: echo 'Release URL ${{ steps.automatic_releases.outputs.upload_url }}'
   
   Notification:
     if: ${{ github.event_name == 'push' && github.repository == 'BitCrackers/AmongUsMenu' }}
     runs-on: ubuntu-latest
-    needs: [Release, Debug]
+    needs: [BuildAndRelease]
     steps:
       - name: Discord Notification
         uses: rjstone/discord-webhook-notify@v1.0.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
             echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
             echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
-	    
+      
       - name: Download Release Artifact
         uses: actions/download-artifact@v2.0.9
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
       
-      # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
+      # used solely for backwards compat, can remove once bitbot is updated to use the release instead of the artifacts
       - name: Upload Release Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
         
-        # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
+        # used solely for backwards compat, can remove once bitbot is updated to use the release instead of the artifacts
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
@@ -95,21 +95,24 @@ jobs:
             Release_${{ github.sha }}.zip
             Debug_${{ github.sha }}.zip
             
-        # note, we can invoke the discord webhook here and send it ${{ steps.automatic_releases.outputs.upload_url }} for a direct link to the release
-        # if we do that we can probably remove the artifact uploads entirely unless there's a reason to keep them?
-      - name: Debug Discord
-        if: ${{ github.event_name == 'push' }}
-        run: echo 'Release URL ${{ steps.automatic_releases.outputs.upload_url }}'
   
   Notification:
     if: ${{ github.event_name == 'push' && github.repository == 'BitCrackers/AmongUsMenu' }}
     runs-on: ubuntu-latest
     needs: [BuildAndRelease]
     steps:
+      - name: Parse tag into env
+        # credit: mcraiha via [https://github.community/t/how-to-get-just-the-tag-name/16241/17]
+        id: get_tag
+        shell: bash
+        run: echo ::set-output name=THIS_TAG::${GITHUB_REF/refs\/tags\//}
+      - name: Debug tag parsing
+        run: echo '${{ steps.get_tag.outputs.THIS_TAG }}'
       - name: Discord Notification
         uses: rjstone/discord-webhook-notify@v1.0.4
         with:
           severity: info
           description: "Project Build"
-          details: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # note: we could also link directly to the asset, but that might not be very user-friendly
+          details: "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.get_tag.outputs.THIS_TAG }}"
           webhookUrl: ${{ secrets.DISCORD_BUILD_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             
       - name: Package Builds
         if: ${{ github.event_name == 'push' }}
-        run: tar -caf Release_${{ github.sha }}.zip ./Release/AmongUsMenu.dll ./Release_Version/version.dll ./LICENSE
+        run: tar -caf Release_${{ github.sha }}.zip Release/AmongUsMenu.dll Release_Version/version.dll LICENSE
       
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
@@ -77,7 +77,7 @@ jobs:
             
       - name: Package Builds
         if: ${{ github.event_name == 'push' }}
-        run: tar -caf Debug_${{ github.sha }}.zip ./Debug/AmongUsMenu.dll ./Debug_Version/version.dll ./LICENSE
+        run: tar -caf Debug_${{ github.sha }}.zip Debug/AmongUsMenu.dll Debug_Version/version.dll LICENSE
         
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       
-      - name: Build
+      - name: Build Release
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release'
+        
+      - name: Build Release_Version
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
       
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
@@ -26,26 +30,26 @@ jobs:
           name: Release
           path: |
             ./Release/AmongUsMenu.dll
-            ./LICENSE
-  
-  Release_Version:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      
-      - name: Build
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
-      
-      - name: Upload Artifact
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
-        with:
-          name: Release_Version
-          path: |
             ./Release_Version/version.dll
             ./LICENSE
+            
+      - name: Package Builds
+        if: ${{ github.event_name == 'push' }}
+        run: tar -caf Release_${{ github.sha }}.zip ./Release/AmongUsMenu.dll ./Release_Version/version.dll ./LICENSE
+      
+      - name: Automatic Releases
+        if: ${{ github.event_name == 'push' }}
+        uses: marvinpinto/action-automatic-releases@latest
+        id: "automatic_releases"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest-release"
+          prerelease: true
+          title: "Release Build"
+          files: |
+            Release_${{ github.sha }}.zip
+      # note, we can invoke the discord webhook here and send it ${{ steps.automatic_releases.outputs.upload_url }} for a direct link to the release
+      # if we do that we can probably remove the artifact uploads entirely unless there's a reason to keep them?
 
   Debug:
     runs-on: windows-latest
@@ -53,9 +57,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       
-      - name: Build
+      - name: Build Debug
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug'
+        
+      - name: Build Debug_Version
+        shell: bash
+        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
       
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
@@ -64,31 +72,29 @@ jobs:
           name: Debug
           path: |
             ./Debug/AmongUsMenu.dll
-            ./LICENSE
-  
-  Debug_Version:
-    runs-on: windows-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      
-      - name: Build
-        shell: bash
-        run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
-      
-      - name: Upload Artifact
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/upload-artifact@v2.2.1
-        with:
-          name: Debug_Version
-          path: | 
             ./Debug_Version/version.dll
             ./LICENSE
+            
+      - name: Package Builds
+        if: ${{ github.event_name == 'push' }}
+        run: tar -caf Debug_${{ github.sha }}.zip ./Debug/AmongUsMenu.dll ./Debug_Version/version.dll ./LICENSE
+        
+      - name: Automatic Releases
+        if: ${{ github.event_name == 'push' }}
+        uses: marvinpinto/action-automatic-releases@latest
+        id: "automatic_releases"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest-debug"
+          prerelease: true
+          title: "Debug Build"
+          files: |
+            Debug_${{ github.sha }}.zip
   
   Notification:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' && github.repository == "BitCrackers/AmongUsMenu" }}
     runs-on: ubuntu-latest
-    needs: [Release, Release_Version, Debug, Debug_Version]
+    needs: [Release, Debug]
     steps:
       - name: Discord Notification
         uses: rjstone/discord-webhook-notify@v1.0.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build Project
 
 on:
   push:
-    branches: 
-      - main
+    tags: 
+      - v[0-9].[0-9]+.[0-9]+*
+  # pr's will trigger this action. i think the idea here is to verify that a build is passing before merging.
   pull_request:
     branches: 
       - main
@@ -12,6 +13,24 @@ jobs:
   Release:
     runs-on: windows-latest
     steps:
+      - name: Parse tag semver
+        uses: booxmedialtd/ws-action-parse-semver@3576f3a20a39f8752fe0d8195f5ed384090285dc
+        id: semver_parser
+        with:
+          input_string: ${{ github.ref }}
+          version_extractor_regex: '\/v(.*)$'
+        
+        # please keep this for an adjustment period, will help diagnose any issues
+      - name: Debug semver
+        run: |
+            echo 'major: ${{ steps.semver_parser.outputs.major }}'
+            echo 'minor: ${{ steps.semver_parser.outputs.minor }}'
+            echo 'patch: ${{ steps.semver_parser.outputs.patch }}'
+            echo 'feature (is pre-release?): ${{ steps.semver_parser.outputs.prerelease }}'
+            echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
+            echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
+            echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
+          
       - name: Checkout
         uses: actions/checkout@v2.3.4
       
@@ -23,6 +42,7 @@ jobs:
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Release_Version'
       
+      # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
@@ -39,21 +59,39 @@ jobs:
       
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
         id: "automatic_releases"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-release"
-          prerelease: true
+          prerelease: ${{ steps.semver_parser.outputs.prerelease != 0 }}
           title: "Release Build"
           files: |
             Release_${{ github.sha }}.zip
       # note, we can invoke the discord webhook here and send it ${{ steps.automatic_releases.outputs.upload_url }} for a direct link to the release
       # if we do that we can probably remove the artifact uploads entirely unless there's a reason to keep them?
-
+      
   Debug:
+    # note, this job can probably be merged into the above job for a slightly faster action
     runs-on: windows-latest
     steps:
+      - name: Parse tag semver
+        uses: booxmedialtd/ws-action-parse-semver@3576f3a20a39f8752fe0d8195f5ed384090285dc
+        id: semver_parser
+        with:
+          input_string: ${{ github.ref }}
+          version_extractor_regex: '\/v(.*)$'
+        
+        # please keep this for an adjustment period, will help diagnose any issues
+      - name: Debug semver
+        run: |
+            echo 'major: ${{ steps.semver_parser.outputs.major }}'
+            echo 'minor: ${{ steps.semver_parser.outputs.minor }}'
+            echo 'patch: ${{ steps.semver_parser.outputs.patch }}'
+            echo 'feature (is pre-release?): ${{ steps.semver_parser.outputs.prerelease }}'
+            echo 'feature ver: ${{ steps.semver_parser.outputs.build }}'
+            echo 'full: ${{ steps.semver_parser.outputs.fullversion }}'
+            echo 'is pre-release: ${{ steps.semver_parser.outputs.prerelease != 0 }}'
+            
       - name: Checkout
         uses: actions/checkout@v2.3.4
       
@@ -65,6 +103,7 @@ jobs:
         shell: bash
         run: '"/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/MSBuild.exe" -property:Configuration=Debug_Version'
       
+      # used solely for backwards compat, can remove once all the discord stuff is changed to use the release instead of the artifacts
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' }}
         uses: actions/upload-artifact@v2.2.1
@@ -81,12 +120,11 @@ jobs:
         
       - name: Automatic Releases
         if: ${{ github.event_name == 'push' }}
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@526ce12c6675bbe6e0e9a4169c90d09a3f7ad3e2
         id: "automatic_releases"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-debug"
-          prerelease: true
+          prerelease: ${{ steps.semver_parser.outputs.prerelease != 0 }}
           title: "Debug Build"
           files: |
             Debug_${{ github.sha }}.zip

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include "gitparams.h"
 
-// test 'feature/automatic-releases' featureBranch 1.1.2
+// test 'feature/automatic-releases' featureBranch 1.1.3
 
 HMODULE hModule;
 HANDLE hUnloadEvent;

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,6 +14,8 @@
 #include <sstream>
 #include "gitparams.h"
 
+// test 'feature/automatic-releases'
+
 HMODULE hModule;
 HANDLE hUnloadEvent;
 

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,6 +14,8 @@
 #include <sstream>
 #include "gitparams.h"
 
+// test autoRelease main ver increment
+
 HMODULE hModule;
 HANDLE hUnloadEvent;
 

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,8 +14,6 @@
 #include <sstream>
 #include "gitparams.h"
 
-// test 'feature/automatic-releases' featureBranch 1.1.4
-
 HMODULE hModule;
 HANDLE hUnloadEvent;
 

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include "gitparams.h"
 
-// test 'feature/automatic-releases'
+// test 'feature/automatic-releases' featureBranch 1.1.2
 
 HMODULE hModule;
 HANDLE hUnloadEvent;

--- a/user/main.cpp
+++ b/user/main.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include "gitparams.h"
 
-// test 'feature/automatic-releases' featureBranch 1.1.3
+// test 'feature/automatic-releases' featureBranch 1.1.4
 
 HMODULE hModule;
 HANDLE hUnloadEvent;


### PR DESCRIPTION
tag names should follow this format to generate a release:
v1.2.3-featureName1.0.1 <-- generates a prerelease build, ideal for feature branches
v1.2.4 <-- generates a full release, should be for main branch changes only

the core idea behind this change is to be able to push commits liberally w/out triggering the auto-release.
now, if one of your commits is ready to be released for end-user consumption, you simply tag it and push that tag.

the downside is that the name format of the tag *MUST* be followed.

*when* the version should be incremented is up for discussion: should it be incremented based on how many commits there have been since the last release, or should it be incremented based on release count alone?