### PR TITLE
Revert custom chat hook

### DIFF
--- a/appdata/il2cpp-functions.h
+++ b/appdata/il2cpp-functions.h
@@ -180,5 +180,4 @@ DO_APP_FUNC(bool, EOSManager_IsFreechatAllowed, (EOSManager* __this, MethodInfo*
 
 DO_APP_FUNC(void, TextMeshPro_SetFaceColor, (TextMeshPro* __this, Color32 color, MethodInfo* method), "Unity.TextMeshPro, System.Void TMPro.TextMeshPro::SetFaceColor(UnityEngine.Color32)");
 DO_APP_FUNC(void, TextMeshPro_SetOutlineColor, (TextMeshPro* __this, Color32 color, MethodInfo* method), "Unity.TextMeshPro, System.Void TMPro.TextMeshPro::SetOutlineColor(UnityEngine.Color32)");
-DO_APP_FUNC(bool, TextBoxTMP_IsCharAllowed, (TextBoxTMP* __this, uint16_t unicode_char, MethodInfo* method), "Assembly-CSharp, System.Boolean TextBoxTMP::IsCharAllowed(System.Char)");
 DO_APP_FUNC(Color32, Color32_op_Implicit, (Color c, MethodInfo* method), "UnityEngine.CoreModule, UnityEngine.Color32 UnityEngine.Color32::op_Implicit(UnityEngine.Color)");

--- a/hooks/Chat.cpp
+++ b/hooks/Chat.cpp
@@ -5,7 +5,6 @@
 #include "state.hpp"
 
 void dChatController_AddChat(ChatController* __this, PlayerControl* sourcePlayer, String* chatText, MethodInfo* method) {
-	//Modify chat text here for markup
 	if (State.ReadGhostMessages) {
 		bool wasDead = false;
 		GameData_PlayerInfo* player = GetPlayerData(sourcePlayer);
@@ -58,10 +57,4 @@ void dChatController_Update(ChatController* __this, MethodInfo* method)
 	SaveManager__TypeInfo->static_fields->chatModeType = 1;
 	SaveManager__TypeInfo->static_fields->isGuest = false;
 	ChatController_Update(__this, method);
-}
-
-//This should apply to all text fields, not just chat
-bool dTextBoxTMP_IsCharAllowed(TextBoxTMP* __this, uint16_t unicode_char, MethodInfo* method)
-{
-	return (unicode_char != 0x08); //List invalid characters here
 }

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -113,7 +113,6 @@ void DetourInitilization() {
 	HOOKFUNC(EOSManager_ReallyBeginFlow);
 	HOOKFUNC(EOSManager_IsFreechatAllowed);
 	HOOKFUNC(ChatController_Update);
-	HOOKFUNC(TextBoxTMP_IsCharAllowed);
 
 	if (!HookFunction(&(PVOID&)oPresent, dPresent, "D3D_PRESENT_FUNCTION")) return;
 
@@ -184,7 +183,6 @@ void DetourUninitialization()
 	UNHOOKFUNC(EOSManager_ReallyBeginFlow);
 	UNHOOKFUNC(EOSManager_IsFreechatAllowed);
 	UNHOOKFUNC(ChatController_Update);
-	UNHOOKFUNC(TextBoxTMP_IsCharAllowed);
 
 	if (DetourDetach(&(PVOID&)oPresent, dPresent) != 0) return;
 

--- a/hooks/_hooks.h
+++ b/hooks/_hooks.h
@@ -64,4 +64,3 @@ void dEOSManager_BeginLoginFlow(EOSManager* __this, MethodInfo* method);
 void dEOSManager_ReallyBeginFlow(EOSManager* __this, MethodInfo* method);
 bool dEOSManager_IsFreechatAllowed(EOSManager* __this, MethodInfo* method);
 void dChatController_Update(ChatController* __this, MethodInfo* method);
-bool dTextBoxTMP_IsCharAllowed(TextBoxTMP* __this, uint16_t unicode_char, MethodInfo* method);


### PR DESCRIPTION
Using symbols now results in a ban, so reverting this feature.