### PR TITLE
#272: Shapeshifting doesn't change name

### DIFF
--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -44,29 +44,20 @@ void dPlayerControl_FixedUpdate(PlayerControl* __this, MethodInfo* method) {
 			return;
 		
 		Color32 faceColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->Black, NULL);
-		std::string playerName = convert_from_string(GetPlayerOutfit(playerData)->fields._playerName);
+		Color32 roleColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->White, NULL);
+		std::string playerName = convert_from_string(GetPlayerOutfit(playerData, true)->fields._playerName);
 		if (State.RevealRoles || PlayerIsImpostor(localData))
 		{
-
 			std::string roleName = GetRoleName(playerData->fields.Role, State.AbbreviatedRoleNames);
 			playerName += "\n<size=50%>(" + roleName + ")";
-			String* playerNameStr = convert_to_string(playerName);
-			app::TMP_Text_set_text((app::TMP_Text*)nameTextTMP, playerNameStr, NULL);
-
-			Color32 c = app::Color32_op_Implicit(GetRoleColor(playerData->fields.Role), NULL);
-			app::TextMeshPro_SetFaceColor(nameTextTMP, c, NULL);
-			app::TextMeshPro_SetOutlineColor(nameTextTMP, faceColor, NULL);
+			roleColor = app::Color32_op_Implicit(GetRoleColor(playerData->fields.Role), NULL);
 		}
-		else
-		{
-			String* playerNameStr = convert_to_string(playerName);
-			app::TMP_Text_set_text((app::TMP_Text*)nameTextTMP, playerNameStr, NULL);
 
-			Color32 c = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->White, NULL);
-			app::TextMeshPro_SetFaceColor(nameTextTMP, c, NULL);
-			app::TextMeshPro_SetOutlineColor(nameTextTMP, faceColor, NULL);
-		}
-			
+		String* playerNameStr = convert_to_string(playerName);
+		app::TMP_Text_set_text((app::TMP_Text*)nameTextTMP, playerNameStr, NULL);
+		app::TextMeshPro_SetFaceColor(nameTextTMP, roleColor, NULL);
+		app::TextMeshPro_SetOutlineColor(nameTextTMP, faceColor, NULL);
+
 		if (State.Wallhack && __this == *Game::pLocalPlayer && !State.FreeCam && !State.playerToFollow.has_value()) {
 			auto mainCamera = Camera_get_main(NULL);
 
@@ -95,10 +86,6 @@ void dPlayerControl_FixedUpdate(PlayerControl* __this, MethodInfo* method) {
 				if(State.EnableZoom && !State.InMeeting && State.CameraHeight > 3.0f)
 				Transform_set_position(cameraTransform, { cameraVector3.x, cameraVector3.y, 100 }, NULL);
 			}
-		}
-
-		if ((__this == *Game::pLocalPlayer) && (State.originalColor == 0xFF)) {
-			SaveOriginalAppearance();
 		}
 
 		if ((__this == *Game::pLocalPlayer) && (State.originalColor == 0xFF)) {

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -593,15 +593,24 @@ void ResetOriginalAppearance()
 	State.originalColor = 0xFF;
 }
 
-GameData_PlayerOutfit* GetPlayerOutfit(GameData_PlayerInfo* player) {
+GameData_PlayerOutfit* GetPlayerOutfit(GameData_PlayerInfo* player, bool includeShapeshifted) {
 	auto arr = player->fields.Outfits->fields.entries;
-	for (int i = 0; i < player->fields.Outfits->fields.count; i++) {
+	auto outfitCount = player->fields.Outfits->fields.count;
+	GameData_PlayerOutfit* playerOutfit = NULL;
+	for (int i = 0; i < outfitCount; i++) {
 		auto kvp = arr->vector[i];
 		if (kvp.key == PlayerOutfitType__Enum::Default) {
-			return kvp.value;
+			if(playerOutfit == nullptr)
+				playerOutfit = kvp.value;
+			if(!includeShapeshifted)
+				break;
+		}
+		if (kvp.key == PlayerOutfitType__Enum::Shapeshifted && !convert_from_string(kvp.value->fields._playerName).empty()) {
+			playerOutfit = kvp.value;
+			break;
 		}
 	}
-	return 0;
+	return playerOutfit ? playerOutfit : 0;
 }
 
 bool PlayerIsImpostor(GameData_PlayerInfo* player) {

--- a/user/utility.h
+++ b/user/utility.h
@@ -122,6 +122,6 @@ int GetRandomColorId();
 void SaveOriginalAppearance();
 void ResetOriginalAppearance();
 bool PlayerIsImpostor(GameData_PlayerInfo* player);
-GameData_PlayerOutfit* GetPlayerOutfit(GameData_PlayerInfo* player);
+GameData_PlayerOutfit* GetPlayerOutfit(GameData_PlayerInfo* player, bool includeShapeshifted = false);
 Color GetRoleColor(RoleBehaviour* roleBehaviour);
 std::string GetRoleName(RoleBehaviour* roleBehaviour, bool abbreviated = false);


### PR DESCRIPTION
This fixes a shapeshifted imposter still appearing with his original name instead of the shapeshifted name.
Only affects the player visually.
Players in Eventlog, Tasklist, Meeting HUD will still be the same as before.