### PR TITLE
Fix: Roles are always visible if you are Imposter

### DIFF
--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -14,6 +14,7 @@ namespace PlayersTab {
 			if (ImGui::BeginTabItem("Players")) {
 				ImGui::BeginChild("players#list", ImVec2(200, 0), true);
 				ImGui::ListBoxHeader("", ImVec2(200, 150));
+				auto localData = GetPlayerData(*Game::pLocalPlayer);
 				for (auto playerData : GetAllPlayerData()) {
 					if (playerData->fields.Disconnected) continue;
 
@@ -30,26 +31,22 @@ namespace PlayersTab {
 					ImGui::Dummy(ImVec2(0, 0));
 					ImGui::SameLine();
 
-					ImVec4 nameColor;
-					if (State.RevealRoles && false /* who the imposter is is no longer being sent to the client */)
-						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->ImpostorRed);
-					else if (PlayerSelection(playerData).is_LocalPlayer() || std::count(State.aumUsers.begin(), State.aumUsers.end(), playerData->fields.PlayerId))
-						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->Orange);
-					else
-						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->White);
-
-					if (playerData->fields.IsDead) nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->DisabledGrey);
-
+					ImVec4 nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->White);
 					if (State.RevealRoles)
 					{
 						std::string roleName = GetRoleName(playerData->fields.Role);
-						std::string playerNameWithRole = playerName + "(" + roleName + ")";
-						ImGui::TextColored(nameColor, playerNameWithRole.c_str());
+						playerName = playerName + " (" + roleName + ")";
+						nameColor = AmongUsColorToImVec4(GetRoleColor(playerData->fields.Role));
 					}
-					else
-					{
-						ImGui::TextColored(nameColor, playerName.c_str());
-					}
+					else if(PlayerIsImpostor(localData) && PlayerIsImpostor(playerData))
+						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->ImpostorRed);
+					else if (PlayerSelection(playerData).is_LocalPlayer() || std::count(State.aumUsers.begin(), State.aumUsers.end(), playerData->fields.PlayerId))
+						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->Orange);
+
+					if (playerData->fields.IsDead)
+						nameColor = AmongUsColorToImVec4(Palette__TypeInfo->static_fields->DisabledGrey);
+
+					ImGui::TextColored(nameColor, playerName.c_str());
 				}
 				ImGui::ListBoxFooter();
 

--- a/hooks/MeetingHud.cpp
+++ b/hooks/MeetingHud.cpp
@@ -25,27 +25,24 @@ void dMeetingHud_Update(MeetingHud* __this, MethodInfo* method) {
 		auto localData = GetPlayerData(*Game::pLocalPlayer);
 		auto playerNameTMP = playerVoteArea->fields.NameText;
 
-
 		if (playerData && localData) {
 			Color32 faceColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->Black, NULL);
+			Color32 roleColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->White, NULL);
 			std::string playerName = convert_from_string(GetPlayerOutfit(playerData)->fields._playerName);
-			String* playerNameStr;
-			Color32 outlineColor;
-			if (State.RevealRoles || PlayerIsImpostor(localData)) {
-
+			if (State.RevealRoles)
+			{
 				std::string roleName = GetRoleName(playerData->fields.Role, State.AbbreviatedRoleNames);
 				playerName += "\n<size=50%>(" + roleName + ")";
-				playerNameStr = convert_to_string(playerName);
-
-				outlineColor = app::Color32_op_Implicit(GetRoleColor(playerData->fields.Role), NULL);
+				roleColor = app::Color32_op_Implicit(GetRoleColor(playerData->fields.Role), NULL);
 			}
-			else {
-				playerNameStr = convert_to_string(playerName);
-
-				outlineColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->White, NULL);
+			else if (PlayerIsImpostor(localData) && PlayerIsImpostor(playerData))
+			{
+				roleColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->ImpostorRed, NULL);
 			}
+
+			String* playerNameStr = convert_to_string(playerName);
 			app::TMP_Text_set_text((app::TMP_Text*)playerNameTMP, playerNameStr, NULL);
-			app::TextMeshPro_SetFaceColor(playerNameTMP, outlineColor, NULL);
+			app::TextMeshPro_SetFaceColor(playerNameTMP, roleColor, NULL);
 			app::TextMeshPro_SetOutlineColor(playerNameTMP, faceColor, NULL);
 		}
 		//This is to not show the "Force skip all" that a host does at the end of a meeting

--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -46,11 +46,15 @@ void dPlayerControl_FixedUpdate(PlayerControl* __this, MethodInfo* method) {
 		Color32 faceColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->Black, NULL);
 		Color32 roleColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->White, NULL);
 		std::string playerName = convert_from_string(GetPlayerOutfit(playerData, true)->fields._playerName);
-		if (State.RevealRoles || PlayerIsImpostor(localData))
+		if (State.RevealRoles)
 		{
 			std::string roleName = GetRoleName(playerData->fields.Role, State.AbbreviatedRoleNames);
 			playerName += "\n<size=50%>(" + roleName + ")";
 			roleColor = app::Color32_op_Implicit(GetRoleColor(playerData->fields.Role), NULL);
+		}
+		else if (PlayerIsImpostor(localData) && PlayerIsImpostor(playerData))
+		{
+			roleColor = app::Color32_op_Implicit(Palette__TypeInfo->static_fields->ImpostorRed, NULL);
 		}
 
 		String* playerNameStr = convert_to_string(playerName);

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -618,7 +618,7 @@ bool PlayerIsImpostor(GameData_PlayerInfo* player) {
 	if (player->fields.Role == nullptr) return false;
 
 	RoleBehaviour* role = player->fields.Role;
-	return role->fields.Role == RoleTypes__Enum::Impostor;
+	return role->fields.TeamType == RoleTeamTypes__Enum::Impostor;
 }
 
 


### PR DESCRIPTION
This changes the behaviour as follows:
- If you Reveal Roles, all Roles and Colors are visible during game, in meeting and player tab.
- If you are Imposter, you see yourself and all other Imposters also in Red during game, in meeting and player tab.
- If you are Crewmate (or Crewmate Role), you see all players in standard white during game, in meeting and player tab.