### PR TITLE
Fix instant win if no roles were selected / present

### DIFF
--- a/hooks/RoleManager.cpp
+++ b/hooks/RoleManager.cpp
@@ -11,7 +11,7 @@
 void dRoleManager_SelectRoles(RoleManager* __this, MethodInfo* method) {
 	std::vector<uint8_t> assignedPlayers;
 	auto allPlayers = GetAllPlayerControl();
-	auto roleRates = RoleRates((*Game::pGameOptionsData)->fields.RoleOptions);
+	auto roleRates = RoleRates((*Game::pGameOptionsData)->fields);
 
 	AssignPreChosenRoles(roleRates, assignedPlayers);
 	AssignRoles(roleRates.ShapeshifterCount, roleRates.ShapeshifterChance, RoleTypes__Enum::Shapeshifter, allPlayers, assignedPlayers);
@@ -45,12 +45,14 @@ void AssignPreChosenRoles(RoleRates& roleRates, std::vector<uint8_t>& assignedPl
 			if (roleRates.ShapeshifterCount == 0)
 				continue;
 			roleRates.ShapeshifterCount--;
+			roleRates.ImposterCount--;
 		}
 		else if (trueRole == RoleTypes__Enum::Impostor)
 		{
 			if (roleRates.ImposterCount == 0)
 				continue;
 			roleRates.ImposterCount--;
+			roleRates.ShapeshifterCount--;
 		}
 		else if (trueRole == RoleTypes__Enum::Scientist)
 		{

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -15,8 +15,9 @@ int randi(int lo, int hi) {
 	return lo + i;
 }
 
-RoleRates::RoleRates(RoleOptionsData* roleOptions) {
-	auto roleRates = roleOptions->fields.roleRates;
+RoleRates::RoleRates(GameOptionsData__Fields gameOptionsDataFields) {
+	this->ImposterCount = gameOptionsDataFields.NumImpostors;
+	auto roleRates = gameOptionsDataFields.RoleOptions->fields.roleRates;
 	if (roleRates->fields.count != 0) {
 		auto vectors = roleRates->fields.entries[0].vector;
 		for (auto iVector = 0; iVector < 32; iVector++)

--- a/user/utility.h
+++ b/user/utility.h
@@ -38,7 +38,7 @@ public:
 	int EngineerCount = 0;
 	int EngineerChance = 0;
 	int MaxCrewmates = 15;
-	RoleRates(RoleOptionsData* roleOptions);
+	RoleRates(GameOptionsData__Fields gameOptionsDataFields);
 };
 
 class PlayerSelection {


### PR DESCRIPTION
this should fix if no roles were selected / were saved in role rates.
in this case no imposter was assigned
also fixed an issue with assigning too many shapeshifters / imposters