### PR TITLE
Add stack trace to logs

### DIFF
--- a/rpc/CustomRpcHandler.cpp
+++ b/rpc/CustomRpcHandler.cpp
@@ -8,8 +8,10 @@ void HandleRpc(uint8_t callId, MessageReader* reader) {
 	switch (callId) {
 	case (uint8_t)42069:
 		int32_t playerid = MessageReader_ReadInt32(reader, NULL);
-		STREAM_DEBUG("RPC Received for another AUM User from playerId: " << playerid);
-		if (!std::count(State.aumUsers.begin(), State.aumUsers.end(), playerid)) State.aumUsers.push_back(playerid);
+		if (!std::count(State.aumUsers.begin(), State.aumUsers.end(), playerid)) {
+			State.aumUsers.push_back(playerid);
+			STREAM_DEBUG("RPC Received for another AUM User from playerId: " << playerid);
+		}
 		break;
 	}
 }

--- a/user/logger.cpp
+++ b/user/logger.cpp
@@ -8,11 +8,14 @@ AUMLogger Log;
 
 void AUMLogger::Create()
 {
-	auto path = getModulePath(NULL);
-	auto logPath = path.parent_path() / "aum-log.txt";
-	if (std::filesystem::exists(logPath)) {
-		std::filesystem::remove(logPath);
-	}
+	const auto path = getModulePath(NULL);
+	const auto logPath = path.parent_path() / "aum-log.txt";
+	const auto prevLogPath = path.parent_path() / "aum-prev-log.txt";
+
+	std::error_code errCode;
+	std::filesystem::remove(prevLogPath, errCode);
+	std::filesystem::rename(logPath, prevLogPath, errCode);
+	std::filesystem::remove(logPath, errCode);
 
 	this->filePath = logPath;
 }
@@ -20,6 +23,7 @@ void AUMLogger::Create()
 void AUMLogger::Write(std::string verbosity, std::string source, std::string message)
 {
 	std::stringstream ss;
+	ss << std::format("[{:%EX}]", std::chrono::zoned_time(std::chrono::current_zone(), std::chrono::system_clock::now()));
 	ss << "[" << verbosity << " - " << source << "] " << message << std::endl;
 	std::cout << ss.str();
 


### PR DESCRIPTION
Helps locate potential problems.

**Example:**
logs:
```
[23:03:57][DEBUG - UNITY] ...
[23:03:57][ERROR - AUM] Exception: .?AVexception@std@@
	0x3439e (VERSION) 
	0x2e31c (GameAssembly) 
	0x1f469f (GameAssembly) UnityPalGetTimeZoneDataForID
	0x1b9446 (GameAssembly) il2cpp_runtime_invoke
	0x6ed077 (UnityPlayer) UnityMain
```
screen snapshot:
![cpp_runtime_error](https://user-images.githubusercontent.com/802181/168107265-2ef34696-0b69-4726-b433-97a4189fdec8.png)


