### PR TITLE
Chat Paste Feature

### DIFF
--- a/AmongUsMenu.vcxproj
+++ b/AmongUsMenu.vcxproj
@@ -600,6 +600,7 @@ git rev-parse --abbrev-ref HEAD &gt;&gt;  gitparams.h</Command>
       <LinkTimeCodeGeneration>UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command>

--- a/gui/tabs/self_tab.cpp
+++ b/gui/tabs/self_tab.cpp
@@ -47,6 +47,10 @@ namespace SelfTab {
             if (ImGui::Checkbox("Always show Chat Button", &State.ChatAlwaysActive)) {
                 State.Save();
             }
+            ImGui::SameLine();
+            if (ImGui::Checkbox("Allow Paste in Chat", &State.ChatPaste)) {
+                State.Save();
+            }
             if (ImGui::Checkbox("Read Messages by Ghosts", &State.ReadGhostMessages)) {
                 State.Save();
             }

--- a/hooks/HudManager.cpp
+++ b/hooks/HudManager.cpp
@@ -26,6 +26,11 @@ void dHudManager_Update(HudManager* __this, MethodInfo* method) {
 	HudManager_Update(__this, method);
 	__this->fields.PlayerCam->fields.Locked = State.FreeCam;
 
+	if (__this->fields.Chat) {
+		*(bool*)(((intptr_t)__this->fields.Chat->fields.TextArea) + 0x43) = State.ChatPaste;
+	}
+
+
 	//HudManager_SetHudActive(__this, State.ShowHud, NULL);
 	if (IsInGame()) {
 		auto localData = GetPlayerData(*Game::pLocalPlayer);

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -65,6 +65,7 @@ void Settings::Load() {
         JSON_TRYGET("MaxVision", this->MaxVision);
         JSON_TRYGET("Wallhack", this->Wallhack);
         JSON_TRYGET("UnlockVents", this->UnlockVents);
+        JSON_TRYGET("ChatPaste", this->ChatPaste);
         JSON_TRYGET("RevealRoles", this->RevealRoles);
         JSON_TRYGET("AbbreviatedRoleNames", this->AbbreviatedRoleNames);
         JSON_TRYGET("ChatAlwaysActive", this->ChatAlwaysActive);
@@ -135,6 +136,7 @@ void Settings::Save() {
             {"MaxVision", this->MaxVision},
             {"Wallhack", this->Wallhack},
             {"UnlockVents", this->UnlockVents},
+            {"ChatPaste", this->ChatPaste},
             {"RevealRoles", this->RevealRoles},
             {"AbbreviatedRoleNames", this->AbbreviatedRoleNames},
             {"ChatAlwaysActive", this->ChatAlwaysActive},

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -49,6 +49,7 @@ public:
     bool RevealVotes = false;
     bool RevealAnonymousVotes = false;
 
+    bool ChatPaste = false;
     bool RevealRoles = false;
     bool AbbreviatedRoleNames = false;
     int PrevKillDistance = 0;


### PR DESCRIPTION
Added ability to paste in Chat.

Note:
Currently using offset because
TMPTextbox struct does not exist.
Leaving that up for discussion.

Added:
Checkbox in self tab next to "Chat Always Visible" for "Allow Paste in Chat"
State: ChatPaste