### PR TITLE
[BugFix] Fix role assign issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 </p>
 
 ## Disclaimer
+我知道有人在拿这个分支的码子搞事情。原则上分支主人不能干涉他人的使用和编译行为，但我仍希望你不要故意到处搞破坏。请你至少考虑维护AU的生态环境。
 This project is for Educational Use only. We do not condone this software being used to gain an advantage against other people. I made this project for my university project to show how cheating software works and how it is possible to block these manipulations in the future.
 
 ## Compile (Configurations)

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -42,15 +42,31 @@ namespace HostTab {
 						State.scientists_amount = (int)GetRoleCount(RoleType::Scientist);
 						State.shapeshifters_amount = (int)GetRoleCount(RoleType::Shapeshifter);
 						State.impostors_amount = (int)GetRoleCount(RoleType::Impostor);
+						State.crewmates_amount = (int)GetRoleCount(RoleType::Crewmate);
+
 						if (State.impostors_amount + State.shapeshifters_amount > maxImposterAmount)
 						{
 							if(State.assignedRoles[index] == RoleType::Shapeshifter)
-								State.assignedRoles[index] = RoleType::Engineer;
+								State.assignedRoles[index] = RoleType::Random; //Set to random to avoid bugs.
 							else if(State.assignedRoles[index] == RoleType::Impostor)
 								State.assignedRoles[index] = RoleType::Random;
-							State.shapeshifters_amount = (int)GetRoleCount(RoleType::Shapeshifter);
-							State.impostors_amount = (int)GetRoleCount(RoleType::Impostor);
 						}
+
+						if (State.assignedRoles[index] == RoleType::Engineer || State.assignedRoles[index] == RoleType::Scientist || State.assignedRoles[index] == RoleType::Crewmate) {			
+							if (State.engineers_amount + State.scientists_amount + State.crewmates_amount >= (int)playerAmount)
+								State.assignedRoles[index] = RoleType::Random;
+						} //Some may set all players to non imps. This hangs the game on beginning. Leave space to Random so we have imps.
+
+						if (options.GetGameMode() == GameModes__Enum::HideNSeek)
+						{
+							if (State.assignedRoles[index] == RoleType::Shapeshifter)
+								State.assignedRoles[index] = RoleType::Random;
+							else if (State.assignedRoles[index] == RoleType::Scientist)
+								State.assignedRoles[index] = RoleType::Engineer;
+							else if (State.assignedRoles[index] == RoleType::Crewmate)
+								State.assignedRoles[index] = RoleType::Engineer;
+						} //Assign other roles in hidenseek causes game bug.
+						//These are organized. Do not change the order unless you find it necessary.
 
 						if (!IsInGame()) {
 							SetRoleAmount(RoleTypes__Enum::Engineer, State.engineers_amount);

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -220,6 +220,11 @@ static void onGameEnd() {
     State.aumUsers.clear();
     State.chatMessages.clear();
     std::fill(State.assignedRoles.begin(), State.assignedRoles.end(), RoleType::Random); //Clear Pre assigned roles to avoid bugs.
+    State.engineers_amount = 0;
+    State.scientists_amount = 0;
+    State.shapeshifters_amount = 0;
+    State.impostors_amount = 0;
+    State.crewmates_amount = 0; //We need to reset these. Or if the host doesn't turn on host tab ,these value won't update.
     State.MatchEnd = std::chrono::system_clock::now();
 
     drawing_t& instance = Esp::GetDrawing();

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -9,6 +9,7 @@
 #include "profiler.h"
 #include <sstream>
 #include "esp.hpp"
+#include <algorithm>
 
 void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
 {
@@ -218,6 +219,7 @@ static void onGameEnd() {
     Replay::Reset();
     State.aumUsers.clear();
     State.chatMessages.clear();
+    std::fill(State.assignedRoles.begin(), State.assignedRoles.end(), RoleType::Random); //Clear Pre assigned roles to avoid bugs.
     State.MatchEnd = std::chrono::system_clock::now();
 
     drawing_t& instance = Esp::GetDrawing();

--- a/hooks/RoleManager.cpp
+++ b/hooks/RoleManager.cpp
@@ -60,10 +60,10 @@ void AssignRoles(RoleRates& roleRates, int roleChance, RoleTypes__Enum role, il2
 	auto playerAmount = allPlayers.size();
 	auto maxImposterAmount = GetMaxImposterAmount((int)playerAmount);
 
-	if (role == RoleTypes__Enum::Shapeshifter || role == RoleTypes__Enum::Impostor) {
-		if (State.shapeshifters_amount + State.impostors_amount >= maxImposterAmount)
-			return; //Skip assigns when pre assigned enough imps.
-	}
+	//if (role == RoleTypes__Enum::Shapeshifter || role == RoleTypes__Enum::Impostor) {
+	//	if (State.shapeshifters_amount + State.impostors_amount >= maxImposterAmount)
+	//		return; //Skip assigns when pre assigned enough imps.
+	//}
 
 	if (options.GetGameMode() == GameModes__Enum::HideNSeek) {
 		if (role == RoleTypes__Enum::Impostor)

--- a/hooks/RoleManager.cpp
+++ b/hooks/RoleManager.cpp
@@ -13,11 +13,19 @@ void dRoleManager_SelectRoles(RoleManager* __this, MethodInfo* method) {
 	auto roleRates = RoleRates(options, (int)allPlayers.size());
 
 	AssignPreChosenRoles(roleRates, assignedPlayers);
-	AssignRoles(roleRates, roleRates.ShapeshifterChance, RoleTypes__Enum::Shapeshifter, allPlayers, assignedPlayers);
-	AssignRoles(roleRates, 100, RoleTypes__Enum::Impostor, allPlayers, assignedPlayers);
-	AssignRoles(roleRates, roleRates.ScientistChance, RoleTypes__Enum::Scientist, allPlayers, assignedPlayers);
-	AssignRoles(roleRates, roleRates.EngineerChance, RoleTypes__Enum::Engineer, allPlayers, assignedPlayers);
-	AssignRoles(roleRates, 100, RoleTypes__Enum::Crewmate, allPlayers, assignedPlayers);
+
+	if (options.GetGameMode() != GameModes__Enum::HideNSeek) {
+		AssignRoles(roleRates, roleRates.ShapeshifterChance, RoleTypes__Enum::Shapeshifter, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, 100, RoleTypes__Enum::Impostor, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, roleRates.ScientistChance, RoleTypes__Enum::Scientist, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, roleRates.EngineerChance, RoleTypes__Enum::Engineer, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, 100, RoleTypes__Enum::Crewmate, allPlayers, assignedPlayers);
+	} //Assign normal roles
+	else {
+		AssignRoles(roleRates, 100, RoleTypes__Enum::Impostor, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, 100, RoleTypes__Enum::Engineer, allPlayers, assignedPlayers);
+		AssignRoles(roleRates, 100, RoleTypes__Enum::Crewmate, allPlayers, assignedPlayers); //In case we do not assign everyone.
+	}//Assign hidenseek roles
 }
 
 /*void dRoleManager_AssignRolesForTeam(List_1_GameData_PlayerInfo_* players, RoleOptionsData* opts, RoleTeamTypes__Enum team, int32_t teamMax, Nullable_1_RoleTypes_ defaultRole, MethodInfo* method) {
@@ -47,11 +55,28 @@ void AssignPreChosenRoles(RoleRates& roleRates, std::vector<uint8_t>& assignedPl
 
 void AssignRoles(RoleRates& roleRates, int roleChance, RoleTypes__Enum role, il2cpp::List<List_1_PlayerControl_>& allPlayers, std::vector<uint8_t>& assignedPlayers)
 {
+	GameOptions options;
 	auto roleCount = roleRates.GetRoleCount(role);
+	auto playerAmount = allPlayers.size();
+	auto maxImposterAmount = GetMaxImposterAmount((int)playerAmount);
+
+	if (role == RoleTypes__Enum::Shapeshifter || role == RoleTypes__Enum::Impostor) {
+		if (State.shapeshifters_amount + State.impostors_amount >= maxImposterAmount)
+			return; //Skip assigns when pre assigned enough imps.
+	}
+
+	if (options.GetGameMode() == GameModes__Enum::HideNSeek) {
+		if (role == RoleTypes__Enum::Impostor)
+			roleCount = 1; //Sometime the game would accidently make imp amount > 1.
+		if (role == RoleTypes__Enum::Engineer)
+			roleCount = playerAmount - 1; //For unknown reason Game simply set engineer amount in hidenseek to 0.
+	}
+
+	if (role == RoleTypes__Enum::Shapeshifter && roleCount >= maxImposterAmount)
+		roleCount = maxImposterAmount; //In previous version, aum would assign more imps than MaxImposterAmount based on shapeshifter amount.
+
 	if (roleCount < 1)
 		return;
-
-	auto playerAmount = allPlayers.size();
 
 	for (auto i = 0; i < roleCount; i++)
 	{

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -132,6 +132,7 @@ public:
     int shapeshifters_amount = 0;
     int engineers_amount = 0;
     int scientists_amount = 0;
+    int crewmates_amount = 0;
 
     bool Wallhack = false;
     bool FreeCam = false;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -94,9 +94,12 @@ void RoleRates::SubtractRole(RoleTypes__Enum role) {
 
 int GetMaxImposterAmount(int playerAmount)
 {
-	if(playerAmount >= 9)
+	GameOptions options;
+	if (options.GetGameMode() == GameModes__Enum::HideNSeek)
+		return 1;
+	if (playerAmount >= 9)
 		return 3;
-	if(playerAmount >= 7)
+	if (playerAmount >= 7)
 		return 2;
 	return 1;
 }


### PR DESCRIPTION
Fix #544 
Adjust host tab for the change.
Prevent some people from making everyone non imps in host tab.
Clear pre assigned roles in host tab on game end so we won't meet bugs.
Avoid assign more imps than MaxImposterAmount based on shapeshifter amount.

