### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
         # credit: mcraiha via [https://github.community/t/how-to-get-just-the-tag-name/16241/17]
         id: get_tag
         shell: bash
-        run: echo ::set-output name=THIS_TAG::${GITHUB_REF/refs\/tags\//}
+        run: echo "THIS_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
         
       - name: Debug tag parsing
         run: echo '${{ steps.get_tag.outputs.THIS_TAG }}'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


